### PR TITLE
Handle "hold" properly in tuya_1_to_4_buttons.yaml

### DIFF
--- a/zigbee2mqtt-tuya_1_to_4_buttons.yaml
+++ b/zigbee2mqtt-tuya_1_to_4_buttons.yaml
@@ -21,7 +21,7 @@ blueprint:
       selector:
         entity:
           domain:
-          - event
+            - event
           multiple: true
     button_1_short_press:
       name: Single Press - Button 1
@@ -90,7 +90,7 @@ blueprint:
       selector:
         action: {}
     button_4_hold:
-      name: Long Press - Button 4
+      name: Hold - Button 4
       description: Action to run on button 4 hold press
       default: []
       selector:
@@ -105,15 +105,16 @@ condition:
 action:
   - variables:
       event_type: "{{ trigger.to_state.attributes.event_type }}"
+      button: "{{ trigger.to_state.attributes.button | default('undefined') }}"
   - choose:
       - conditions:
-          - "{{ event_type in ['1_single', 'single'] }}"
+          - "{{ event_type == '1_single' }}"
         sequence: !input button_1_short_press
       - conditions:
-          - "{{ event_type in ['1_double', 'double'] }}"
+          - "{{ event_type == '1_double' }}"
         sequence: !input button_1_double_press
       - conditions:
-          - "{{ event_type in ['1_hold', 'hold'] }}"
+          - "{{ event_type == 'hold' and button == 1 }}"
         sequence: !input button_1_hold
       - conditions:
           - "{{ event_type == '2_single' }}"
@@ -122,7 +123,7 @@ action:
           - "{{ event_type == '2_double' }}"
         sequence: !input button_2_double_press
       - conditions:
-          - "{{ event_type == '2_hold' }}"
+          - "{{ event_type == 'hold' and button == 2 }}"
         sequence: !input button_2_hold
       - conditions:
           - "{{ event_type == '3_single' }}"
@@ -131,7 +132,7 @@ action:
           - "{{ event_type == '3_double' }}"
         sequence: !input button_3_double_press
       - conditions:
-          - "{{ event_type == '3_hold' }}"
+          - "{{ event_type == 'hold' and button == 3 }}"
         sequence: !input button_3_hold
       - conditions:
           - "{{ event_type == '4_single' }}"
@@ -140,5 +141,10 @@ action:
           - "{{ event_type == '4_double' }}"
         sequence: !input button_4_double_press
       - conditions:
-          - "{{ event_type == '4_hold' }}"
+          - "{{ event_type == 'hold' and button == 4 }}"
         sequence: !input button_4_hold
+    default:
+      - action: logbook.log
+        data_template:
+          name: "Zigbee2MQTT - Tuya 1 to 4 Buttons"
+          message: "event_type=={{ repr(event_type) }} and button=={{ repr(button) }}"


### PR DESCRIPTION
Per https://github.com/Koenkk/zigbee2mqtt/issues/25772 z2m reports `<buttonNo>_<eventType>` for `single` and `double` events, but just `hold` for the long press. To determine which button is pressed you have to use `button` (and be sure to compare it to a numeric — not a string! — value). I added logging to see when the events are not processed correctly.